### PR TITLE
Download gzipped abstracts from NCBI to sumner

### DIFF
--- a/scripts/abstracts.sh
+++ b/scripts/abstracts.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --qos=batch
+#SBATCH --time=10:00:00
+#SBATCH --mem-per-cpu=10G
+#SBATCH --mail-user=hannah.blau@jax.org
+#SBATCH --mail-type=END,FAIL
+
+module load singularity
+
+singularity pull library://fenz/prova/python:3.8.2
+singularity exec python_3.8.2.sif python retrieve_pubmed_files.py

--- a/scripts/retrieve_pubmed_files.py
+++ b/scripts/retrieve_pubmed_files.py
@@ -6,9 +6,11 @@ import socket
 from urllib.request import Request, urlopen
 from urllib.error import URLError
 
-DOWNLOADS_DIR = '../downloads/'
+DOWNLOADS_DIR = '/projects/robinson-lab/PMP/'
+# DOWNLOADS_DIR = '../downloads/'
 PUBMED_DIR = DOWNLOADS_DIR + 'pubmed/'
-ftp_filenames = DOWNLOADS_DIR + 'subset_medline_links.txt'
+# ftp_filenames = DOWNLOADS_DIR + 'medline_ftp_links.txt'
+ftp_filenames = 'medline_ftp_links.txt'
 
 def main():
     """


### PR DESCRIPTION
This pr contains the bash script to run on sumner (slurm) for downloading gzipped PubMed abstracts from NCBI to the /projects/robinson-lab/PMP/pubmed directory.
