### PR TITLE
Added instance variable for dictionary of words seen previously to MyLemmatizer

### DIFF
--- a/scripts/my_lemmatizer.py
+++ b/scripts/my_lemmatizer.py
@@ -9,10 +9,12 @@ from nltk.stem import WordNetLemmatizer
 class MyLemmatizer(WordNetLemmatizer):
     """
     MyLemmatizer is a regular WordNetLemmatizer that can process not just a
-    single word but a sequence of words.
+    single word but a sequence of words. It remembers words it has seen before
+    to avoid recalculating the same string multiple times.
     """
 
     def __init__(self):
+        self.seen = {}
         super().__init__()
 
     @staticmethod
@@ -29,7 +31,11 @@ class MyLemmatizer(WordNetLemmatizer):
         return tag_dict.get(tag, wordnet.NOUN)
 
     def lemmatize_word(self, word) -> str:
-        return super().lemmatize(word, self.get_wordnet_pos(word))
+        lemmatized = self.seen.get(word)
+        if not lemmatized:
+            lemmatized = super().lemmatize(word, self.get_wordnet_pos(word))
+            self.seen[word] = lemmatized
+        return lemmatized
 
     def lemmatize_seq(self, seq: str) -> str:
         word_list = nltk.word_tokenize(seq)

--- a/tests/test_filter_abstracts.py
+++ b/tests/test_filter_abstracts.py
@@ -95,6 +95,7 @@ class FilterAbstractsTestCase(unittest.TestCase):
         input_dir = 'testdata/pubmed_txt/'
         output_dir = 'testdata/pubmed_rel/'
         makedirs(output_dir, exist_ok=True)
+        # D005796 = Genes, D009369 = Neoplasms, D037102 = Lectins
         test_params = [
             'D005796-D009369-D037102',
             'D009369-D037102',
@@ -145,7 +146,7 @@ class FilterAbstractsTestCase(unittest.TestCase):
                 pmid_key = params + '-m' if major else params
                 find_relevant_abstracts(input_dir + test_filename + '.txt',
                                         output_dir, major, desired)
-                with open(output_dir + test_filename + '_relevant.tsv') as outfile:
+                with open(output_dir + test_filename + '_rel.tsv') as outfile:
                     output_pmids = [line.split()[PMID_INDEX] for line in outfile]
                 self.assertEqual(relevant_pmids[pmid_key], output_pmids,
                                  'Incorrect PMIDs for ' + pmid_key)

--- a/tests/test_query_mesh.py
+++ b/tests/test_query_mesh.py
@@ -48,6 +48,7 @@ class QueryMeshTestCase(unittest.TestCase):
             'D000072481',
             'D000077192',
             'D000080443',
+            'D000086002',
             'D001932',
             'D001984',
             'D002282',
@@ -85,7 +86,7 @@ class QueryMeshTestCase(unittest.TestCase):
             'D056364'
         }
         actual = merge_descendants(ancestors)
-        self.assertEqual(38, len(actual),
+        self.assertEqual(39, len(actual),
                          'Dictionary of descendants for D016543, D011118, D008175 has incorrect length.')
         self.assertEqual(expected, actual.keys(),
                          'Set of descendant descriptors for D016543, D011118, D008175 does not match.')


### PR DESCRIPTION
This pull request makes the text post-processing more efficient by remembering every lemmatized word in a dictionary. Any word is lemmatized only once, the first time it is encountered, and thereafter the lemmatized form can be looked up in the dictionary.