### PR TITLE
No filter

### DIFF
--- a/bash_scripts/bypass_filter.sh
+++ b/bash_scripts/bypass_filter.sh
@@ -16,12 +16,12 @@ shopt -s nullglob
 
 # the purpose of this regex is to isolate the basename of the .txt file so it
 # can be reused for the output filename
-regex='^.*/*(.+)\.[[:alnum:]]{3}$'
+regex='^(.+/)*(.+)\.[[:alnum:]]{3}$'
 for f in "$1"/*
 do
   if [[ $f =~ $regex ]]
   then
-    awk -v FS="##" -v OFS="\t" '{print $1,$2}' $f > "$2/${BASH_REMATCH[1]}_rel.tsv"
+    awk -v FS="##" -v OFS="\t" '{print $1,$2}' $f > "$2/${BASH_REMATCH[2]}_rel.tsv"
     echo "$f"
   else
     echo "regex failure for $f"


### PR DESCRIPTION
This pull request consist of a bash script that bypasses the filtering of PubMed articles for relevance. The script copies directly from the .txt file to the output of PMID and publication date for all articles regardless of what MeSH descriptors or keywords they may have.